### PR TITLE
Fix typos

### DIFF
--- a/white_paper.md
+++ b/white_paper.md
@@ -112,7 +112,8 @@ Citizen can sign the petition and immediately publish online their signature for
 ### Notaries
 
 Notaries are web services receiving publications from participants, including other notaries, and making them public.
-Notaries should communicate with other notaries to gather more publications.
+When a participant publishes something, it means that the participant sends a signed message to a notary and the notary makes it publicly available.
+Notaries should also communicate with other notaries to gather more publications.
 A good notary is a notary which publishes all the available publications of *directdemocracy.vote*.
 Notaries also provide a web user interface to allow anyone to search and browse the various publications.
 

--- a/white_paper.md
+++ b/white_paper.md
@@ -79,11 +79,7 @@ Judges rely on their own algorithms to compute the reputation of participants.
 These algorithms use endorsements as input and may be inspired by the [page rank algorithm](https://en.wikipedia.org/wiki/PageRank).
 They may also take into account the date of the endorsements and the distance between the endorsing citizen and the endorsed citizen.
 However, their implementation is totally left to the judge.
-
-#### Trusted Public Keys
-
-It is very likely that the webs of trust published by different judges will be similar to each other, forming a consensual web of trust.
-This consensual web of trust can in turn be used to evaluate if a key can be trusted.
+It is very likely that the endorsements published by different judges will be similar to each other, thus converging towards a consensual web of trust.
 
 #### Optional Judge Information
 

--- a/white_paper.md
+++ b/white_paper.md
@@ -69,11 +69,15 @@ Judges collect all the endorsements published by the citizens to construct their
 
 #### Reputation
 
-Each judge publishes its own web of trust, which is a list of containing public keys and their associated reputation.
+Judges evaluate the reputation of all the participants: citizens, notaries, pooling stations and other judges.
 The reputation is a number.
-If this number is above a threshold, it means the public key can be trusted.
-Judges rely on their own algorithms to compute the reputation of public keys.
+When the reputation of a participant is above a threshold defined by the judge, the judge publishes an endorsement for this partipant.
+Polling stations query the notaries to check if a citizen was endorsed by the judge of a referendum.
+Anyone can query a judge to get the reputation of a participant.
+The judge shall also display publicly the threshold above which it considers that a participant can be trusted.
+Judges rely on their own algorithms to compute the reputation of participants.
 These algorithms use endorsements as input and may be inspired by the [page rank algorithm](https://en.wikipedia.org/wiki/PageRank).
+They may also take into account the date of the endorsements and the distance between the endorsing citizen and the endorsed citizen.
 However, their implementation is totally left to the judge.
 
 #### Trusted Public Keys

--- a/white_paper.md
+++ b/white_paper.md
@@ -10,8 +10,8 @@ Version: 0.0.2 (draft)
 It relies on the Internet, decentralization and cryptography to guarantee a fair voting system.
 The principle is that people become citizens by getting trusted by others.
 Citizens can vote and propose referendums regardless of any official acknowledgement.
-Referendum results with a low participation could be ignored or considered as simple survey results.
 They could feed debates, influence political decisions and foster more people to become citizens.
+Referendum results with a low participation could be ignored or considered as simple survey results.
 Referendum results with a large participation will become significant from a democratic point of view.
 This will increase the pressure on governments to respect the democratic choices expressed by their people.
 Eventually, governments will officially recognize and contribute to *directdemocracy.vote*.
@@ -26,7 +26,7 @@ I will answer them: *[directdemocracy.vote](https://directdemocracy.vote)*.
 
 I believe that [direct democracy](https://en.wikipedia.org/wiki/Direct_democracy) is the best political system to address the challenges that the humanity is facing: global warming, biodiversity, overpopulation, human rights, peace and prosperity.
 In this political system, any citizen can propose a referendum for a law that will enter in force if a majority of citizens approves it.
-Direct democracy is implemented in a few countries, like Switzerland, where it has proved efficient to address local challenges. 
+Direct democracy is implemented in a few countries, like Switzerland, where it has proved efficient to address local challenges.
 However, many decisions, in particular with respect to ecology and peace, cannot simply be taken at the level of a single country.
 Instead they should be taken globally.
 
@@ -65,7 +65,7 @@ Hence, judges form a community of web services which permanently evaluate the re
 
 In order to help judges in their duties, citizens are asked to endorse each other and to endorse web services.
 Endorsing a citizen is the action of publishing a signed message saying "I certify this public key is unique for this citizen".
-Endorsing a web service is the action of publishing a signed message saying "I believe this web service is honest and doing a good job". 
+Endorsing a web service is the action of publishing a signed message saying "I believe this web service is honest and doing a good job".
 Judges collect all the endorsements published by the citizens to construct their own web of trust.
 
 #### Reputation
@@ -84,11 +84,11 @@ This consensual web of trust can in turn be used to evaluate if a key can be tru
 
 #### Optional Judge Information
 
-Some judges may optionally ask citizens to provide then some private information, which they should keep private.
+Some judges may optionally ask citizens to provide them some private information, which they should keep private.
 This information is useful to assess the reputation of citizens, that is one citizen registration corresponds to a single real individual.
 It may include local voter registration number, phone number, credit card number, ID card number, passport number, social insurance number, etc.
 Such private information should never be made public.
-It is managed by trustess themselves and is out of the scope of the *directdemocracy.vote* system.
+It is managed by judges themselves and is out of the scope of the *directdemocracy.vote* system.
 Citizens are free to choose a judge among several for which they feel confident about the management of their private information.
 Some judges may not require to ask any private information to citizen.
 
@@ -105,6 +105,13 @@ Once a referendum is published, the voting process takes place.
 Citizens use polling stations to cast their vote anonymously and the results are published online.
 Once a petition is published, the signature process takes place.
 Citizen can sign the petition and immediately publish online their signature for this petition.
+
+### Notaries
+
+Notaries are web services receiving publications from participants, including other notaries, and making them public.
+Notaries should communicate with other notaries to gather more publications and possibly delete obsolete publications.
+A good notary is a notary which publishes almost all the available publications of *directdemocracy.vote*.
+Publications can be searched by various criterions: type, key, area, name, date, etc.
 
 ## Properties
 
@@ -125,7 +132,7 @@ Citizens should publish a minimal amount of information about themselves: name, 
 This is necessary to declare to others their existence as a citizen.
 Also other publications are needed by the voting process, like the participation of a citizen to a referendum.
 Such publications are publicly available online and cannot be removed (although they can be revoked by their authors).
-It is a bit similar to what happens with crypto currencies where the transaction information is publicly stored in a block chain.
+It is a bit similar to what happens with crypto currencies where the transaction information is publicly stored in a blockchain.
 
 ### Free and Open Source
 
@@ -199,7 +206,7 @@ The app also generates a password protected revocation message that the particip
 
 The operating system of the smartphone also provides integrity checks on itself and on the app.
 The app integrity check prevents malicious users from using a modified app to cheat or to extract sensitive data.
-The operating system integrity check prevents malicious users from modifying the behavior of the app at run-time or extracting sensitive data. 
+The operating system integrity check prevents malicious users from modifying the behavior of the app at run-time or extracting sensitive data.
 These features are currently offered by the [Android Play Integrity](https://developer.android.com/google/play/integrity) and the [Apple iOS DeviceCheck](https://developer.apple.com/documentation/devicecheck).
 They require however that the app is provided through the official app store of the operating system.
 
@@ -378,9 +385,9 @@ participation: [public key of participation generated by station]
 ```
 
 #### Ballot
-A [ballot publication](https://directdemocracy.vote/json-schema/0.0.2/ballot.schema.json) contains the public key of a referendum, the answer to question of asked in the referendum.
+A [ballot publication](https://directdemocracy.vote/json-schema/0.0.2/ballot.schema.json) contains the public key of a referendum, the answer to the question asked in the referendum.
 Secret ballots are signed by a station.
-Public ballots are signed by citizens. 
+Public ballots are signed by citizens.
 
 Example:
 ```yaml
@@ -403,13 +410,6 @@ signature: [signature of participation]
 published: 1590298858399
 vote: [vote]
 ```
-
-### Notaries
-
-Notaries are web services receiving publications from participants, including other notaries, and making them public.
-Notaries should communicate with other notaries to gather more publications and possibly delete obsolete publications.
-A good notary is a notary which publishes almost all the available publications of *directdemocracy.vote*.
-Publications can be searched by various criterions: type, key, area, name, date, etc.
 
 ## Petitioning
 This section describe the full petitioning process in details.
@@ -490,7 +490,7 @@ If *S* doesn't answer quickly to the *registration* of *A* by publishing a corre
 #### Vote Ballot Mismatch
 
 If for a *S<sub>R</sub>* there is more *votes* than *ballots*, then the station is considered as cheating.
-It that happens, the reputation of the station is immediately distrusted and all its *votes* and *ballots* are ignored.
+If that happens, the reputation of the station is immediately distrusted and all its *votes* and *ballots* are ignored.
 This is unlikely to happen as the interest of stations is to maintain a high reputation on a large number of referendums.
 
 #### Citizen Voting Twice
@@ -597,7 +597,7 @@ We aim at getting *directdemocracy.vote* used by a large number of citizens to i
 In order to achieve this goal, we plan to start small with local petitions and/or referendum in small municipalities, like villages.
 It is likely that there exist many villages in the world where a majority of people disagrees with the local municipality on some topic.
 Thus a couple of citizens in one of these villages may decide to use *directdemocracy.vote* to organize a local referendum.
-The local municipality may decide ignore the outcome of the referendum.
+The local municipality may decide to ignore the outcome of the referendum.
 However, the local news may relay the fact that some citizens self-organized a referendum to increase the pressure on the municipality.
 This will have a side effect to spread the word about *directdemocracy.vote* and encourage other villages or cities to use it.
 At some point, citizens will launch a referendum for a whole region, then a whole country.

--- a/white_paper.md
+++ b/white_paper.md
@@ -107,7 +107,7 @@ Citizen can sign the petition and immediately publish online their signature for
 
 ### Notaries
 
-Notaries are web services receiving publications from participants, including other notaries, and making them public.
+Notaries are web services receiving publications from participants, including other notaries, and making them public to anyone in the world.
 When a participant publishes something, it means that the participant sends a signed message to a notary and the notary makes it publicly available.
 Notaries should also communicate with other notaries to gather more publications.
 A good notary is a notary which publishes all the available publications of *directdemocracy.vote*.

--- a/white_paper.md
+++ b/white_paper.md
@@ -108,9 +108,9 @@ Citizen can sign the petition and immediately publish online their signature for
 ### Notaries
 
 Notaries are web services receiving publications from participants, including other notaries, and making them public.
-Notaries should communicate with other notaries to gather more publications and possibly delete obsolete publications.
-A good notary is a notary which publishes almost all the available publications of *directdemocracy.vote*.
-Publications can be searched by various criterions: type, key, area, name, date, etc.
+Notaries should communicate with other notaries to gather more publications.
+A good notary is a notary which publishes all the available publications of *directdemocracy.vote*.
+Notaries also provide a web user interface to allow anyone to search and browse the various publications.
 
 ## Properties
 

--- a/white_paper.md
+++ b/white_paper.md
@@ -294,7 +294,7 @@ Otherwise, in case of the endorsement of a web service or an app, it means that 
 An important endorsement is the integrity endorsement signed by the app provider which means that a citizen registered their citizen card using the genuine app running on a non-rooted unmodified smartphone.
 A citizen card failing to receive an integrity endorsement from a trusted app provider should not be trusted.
 
-A **revocation** is a special kind of endorsement meant to revoke a publication. It has its revocation field set to true. A revocation can be published by a citizen to revoke her own citizen card. Then, they may create a new card with the same public key or a new public key. Revocations are also published by participants to distrust other participants, or to cancel endorsements they previously published.
+A **revocation** is a special kind of endorsement meant to revoke a publication. It has its revocation field set to true. A revocation can be published by a citizen to revoke her own citizen card. Then, they may create a new card with the same public key or a new public key. Revocations are also published by participants to cancel endorsements they previously published.
 
 Example:
 ```yaml

--- a/white_paper.md
+++ b/white_paper.md
@@ -10,9 +10,8 @@ Version: 0.0.2 (draft)
 It relies on the Internet, decentralization and cryptography to guarantee a fair voting system.
 The principle is that people become citizens by getting trusted by others.
 Citizens can vote and propose referendums regardless of any official acknowledgement.
-They could feed debates, influence political decisions and foster more people to become citizens.
-Referendum results with a low participation could be ignored or considered as simple survey results.
-Referendum results with a large participation will become significant from a democratic point of view.
+Referendum with a low participation could be ignored or considered as simple survey results.
+Referendum with a large participation will become significant from a democratic point of view.
 This will increase the pressure on governments to respect the democratic choices expressed by their people.
 Eventually, governments will officially recognize and contribute to *directdemocracy.vote*.
 The system can be applied locally at the municipal level, or more globally at regional, national or international levels.

--- a/white_paper.md
+++ b/white_paper.md
@@ -83,7 +83,7 @@ This consensual web of trust can in turn be used to evaluate if a key can be tru
 
 #### Optional Judge Information
 
-Some judges may optionally ask citizens to provide them some private information, which they should keep private.
+Some judges may optionally ask citizens to provide them with some private information, which they should keep private.
 This information is useful to assess the reputation of citizens, that is one citizen registration corresponds to a single real individual.
 It may include local voter registration number, phone number, credit card number, ID card number, passport number, social insurance number, etc.
 Such private information should never be made public.


### PR DESCRIPTION
I am not sure of the formulation concerning:  `Each judge publishes its own web of trust, which is a list of containing public keys and their associated reputation. The reputation is a number. If this number is above a threshold, it means the public key can be trusted.`: Shouldn't the judge publish (via the notary) each sworn in citizen individually when it reach the threshold instead of 1. a list, 2. the reputation

`Revocations are also published by participants to distrust other participants, or to cancel endorsements they previously published.`: Can a user distrust a participant (web service or citizen) without previously endorsing it?

It could be good to specify that the notary is the one that publish all messages to the world. It was not clear for me as it is often written `published by the judge/citizen/polling station`